### PR TITLE
Change LineNr coloring to Normal

### DIFF
--- a/colors/nordisk.vim
+++ b/colors/nordisk.vim
@@ -117,7 +117,7 @@ hi! link IncSearch		Search
 hi! link Include		PreProc
 hi! link Keyword		Statement
 hi! link Label			Statement
-hi! link LineNr			Ignore
+hi! link LineNr			Normal
 hi! link Macro			PreProc
 hi! link MatchParen		Search
 hi! link MoreMsg		ModeMsg


### PR DESCRIPTION
Not sure if this is something you intended to to, but line numbers wouldn't show up for me without this change. Still learning vim and the configurations there, so feel free to ignore if you don't want this :)